### PR TITLE
Added type of shifts

### DIFF
--- a/app/assets/stylesheets/administrator/type_of_shifts.scss
+++ b/app/assets/stylesheets/administrator/type_of_shifts.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the administrator/type_of_shifts controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/administrator/type_of_shifts_controller.rb
+++ b/app/controllers/administrator/type_of_shifts_controller.rb
@@ -1,0 +1,51 @@
+class Administrator::TypeOfShiftsController < ApplicationController
+  def index
+    @type_of_shifts = policy_scope([:administrator, TypeOfShift.order(:name_of_shift)])
+  end
+
+  def new
+    @type_of_shift = TypeOfShift.new
+    authorize [:administrator, @type_of_shift]
+  end
+
+  def create
+    @type_of_shift = TypeOfShift.new(shift_params)
+    authorize [:administrator, @type_of_shift]
+    if @type_of_shift.save
+      redirect_to administrator_type_of_shifts_path, notice: "Turno creado correctamente."
+    else
+      render :new
+    end
+  end
+
+  def edit
+    @type_of_shift = TypeOfShift.find(params[:id])
+    authorize [:administrator, @type_of_shift]
+  end
+
+  def update
+    @type_of_shift = TypeOfShift.find(params[:id])
+    authorize [:administrator, @type_of_shift]
+    if @type_of_shift.update(shift_params)
+      redirect_to administrator_type_of_shifts_path, notice: "Turno actualizado correctamente."
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @type_of_shift = TypeOfShift.find(params[:id])
+    authorize [:administrator, @type_of_shift]
+    if @type_of_shift.destroy
+      redirect_to administrator_type_of_shifts_path, notice: "Turno elimanado correctamente."
+    else
+      redirect_to administrator_type_of_shifts_path, alert: "No se ha podido eliminar el turno"
+    end
+  end
+
+  private
+
+  def shift_params
+    params.require(:type_of_shift).permit(:name_of_shift)
+  end
+end

--- a/app/helpers/administrator/type_of_shifts_helper.rb
+++ b/app/helpers/administrator/type_of_shifts_helper.rb
@@ -1,0 +1,2 @@
+module Administrator::TypeOfShiftsHelper
+end

--- a/app/models/type_of_shift.rb
+++ b/app/models/type_of_shift.rb
@@ -1,0 +1,3 @@
+class TypeOfShift < ApplicationRecord
+  validates :name_of_shift, presence: true, uniqueness: true
+end

--- a/app/policies/administrator/type_of_shift_policy.rb
+++ b/app/policies/administrator/type_of_shift_policy.rb
@@ -1,0 +1,27 @@
+class Administrator::TypeOfShiftPolicy < ApplicationPolicy
+  class Scope < Scope
+    def resolve
+      if user.role? :admin
+        scope.all
+      end
+    end
+  end
+  def new?
+    user.role? :admin
+  end
+  def create?
+    user.role? :admin
+  end
+
+  def edit?
+    user.role? :admin
+  end
+
+  def update?
+    user.role? :admin
+  end
+
+  def destroy?
+    user.role? :admin
+  end
+end

--- a/app/views/administrator/type_of_shifts/edit.html.erb
+++ b/app/views/administrator/type_of_shifts/edit.html.erb
@@ -1,0 +1,4 @@
+<%= simple_form_for [:administrator, @type_of_shift] do |f| %>
+  <%= f.input :name_of_shift %>
+  <%= f.submit "Añadir", class: "btn btn_cta"  %>
+<% end %>

--- a/app/views/administrator/type_of_shifts/index.html.erb
+++ b/app/views/administrator/type_of_shifts/index.html.erb
@@ -1,0 +1,5 @@
+<ul>
+  <% @type_of_shifts.each do |l|  %>
+    <li><%= l.name_of_shift %></li>
+  <% end %>
+</ul>

--- a/app/views/administrator/type_of_shifts/new.html.erb
+++ b/app/views/administrator/type_of_shifts/new.html.erb
@@ -1,0 +1,4 @@
+<%= simple_form_for [:administrator, @type_of_shift] do |f| %>
+  <%= f.input :name_of_shift, required: true %>
+  <%= f.submit "Añadir", class: "btn btn_cta"  %>
+<% end %>

--- a/db/migrate/20210902035854_create_type_of_shifts.rb
+++ b/db/migrate/20210902035854_create_type_of_shifts.rb
@@ -1,0 +1,9 @@
+class CreateTypeOfShifts < ActiveRecord::Migration[6.0]
+  def change
+    create_table :type_of_shifts do |t|
+      t.string :name_of_shift
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_02_033304) do
+ActiveRecord::Schema.define(version: 2021_09_02_035854) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -74,6 +74,12 @@ ActiveRecord::Schema.define(version: 2021_09_02_033304) do
 
   create_table "type_of_contracts", force: :cascade do |t|
     t.string "name_type_of_contract"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "type_of_shifts", force: :cascade do |t|
+    t.string "name_of_shift"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/test/controllers/administrator/type_of_shifts_controller_test.rb
+++ b/test/controllers/administrator/type_of_shifts_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Administrator::TypeOfShiftsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/type_of_shifts.yml
+++ b/test/fixtures/type_of_shifts.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name_of_shift: MyString
+
+two:
+  name_of_shift: MyString

--- a/test/models/type_of_shift_test.rb
+++ b/test/models/type_of_shift_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class TypeOfShiftTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/policies/administrator/type_of_shift_policy_test.rb
+++ b/test/policies/administrator/type_of_shift_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class Administrator::TypeOfShiftPolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end


### PR DESCRIPTION
I have:

Created Type Of Shift Model
Creates Type Of Shift controller
CRUD actions for Type Of Shift, this actions can only been performed by the site admin.Group
Type Of Shift Pundit Policy to restrict crud actions to all types of roles except site admin
Type Of Shift validations (presence and uniqueness)