### PR TITLE
Assign emails notification to a user

### DIFF
--- a/app/assets/stylesheets/administrator/assign_email_notifications.scss
+++ b/app/assets/stylesheets/administrator/assign_email_notifications.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the administrator/assign_email_notifications controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/administrator/assign_email_notifications_controller.rb
+++ b/app/controllers/administrator/assign_email_notifications_controller.rb
@@ -1,2 +1,6 @@
 class Administrator::AssignEmailNotificationsController < ApplicationController
+  def index
+    @user = User.find(params[:user_id])
+    @notifications = EmailNotification.all
+  end
 end

--- a/app/controllers/administrator/assign_email_notifications_controller.rb
+++ b/app/controllers/administrator/assign_email_notifications_controller.rb
@@ -1,11 +1,20 @@
 class Administrator::AssignEmailNotificationsController < ApplicationController
   def index
     @user = User.find(params[:user_id])
-    @notifications = EmailNotification.all
+    @notifications = @user.assign_email_notifications
+    authorize [:administrator, @notifications]
   end
 
-  def assign_email_notifications
-    raise
+  # This method changes the active status to activated of deactivated
+  def change_status
+    # We get the assignment email id from de submission, those ones that have to be activated
+    @assignment = AssignEmailNotification.find(params[:id])
+    @assignment.update_active_status
+    if @assignment.active_previously_changed?
+      redirect_to administrator_user_email_notifications_path, notice: " Alerta actualizada correctamente"
+    else
+      redirect_to administrator_user_email_notifications_path, alert: " La alerta no se ha podido actualizar correctamente"
+    end
   end
 
 end

--- a/app/controllers/administrator/assign_email_notifications_controller.rb
+++ b/app/controllers/administrator/assign_email_notifications_controller.rb
@@ -1,0 +1,2 @@
+class Administrator::AssignEmailNotificationsController < ApplicationController
+end

--- a/app/controllers/administrator/assign_email_notifications_controller.rb
+++ b/app/controllers/administrator/assign_email_notifications_controller.rb
@@ -3,4 +3,9 @@ class Administrator::AssignEmailNotificationsController < ApplicationController
     @user = User.find(params[:user_id])
     @notifications = EmailNotification.all
   end
+
+  def assign_email_notifications
+    raise
+  end
+
 end

--- a/app/helpers/administrator/assign_email_notifications_helper.rb
+++ b/app/helpers/administrator/assign_email_notifications_helper.rb
@@ -1,0 +1,2 @@
+module Administrator::AssignEmailNotificationsHelper
+end

--- a/app/models/assign_email_notification.rb
+++ b/app/models/assign_email_notification.rb
@@ -1,0 +1,4 @@
+class AssignEmailNotification < ApplicationRecord
+  belongs_to :user
+  belongs_to :email_notification
+end

--- a/app/models/assign_email_notification.rb
+++ b/app/models/assign_email_notification.rb
@@ -1,4 +1,23 @@
 class AssignEmailNotification < ApplicationRecord
+  ActiveModel::Dirty
   belongs_to :user
   belongs_to :email_notification
+
+  # This method changes the active status to activated of deactivated
+  def update_active_status
+    if active == true
+      update_attribute(:active, false)
+    else active == false
+      update_attribute(:active, true)
+    end
+  end
+
+   # This method displays in a human readable way the current status of an instance.
+  def display_status
+    if active == true
+      'Activado'
+    else
+      'Desactivado'
+    end
+  end
 end

--- a/app/models/email_notification.rb
+++ b/app/models/email_notification.rb
@@ -1,4 +1,7 @@
 class EmailNotification < ApplicationRecord
   validates :notification, presence: true, uniqueness: true
   validates :description, presence: true
+
+  has_many :assign_email_notifications
+  has_many :users, through: :assign_email_notifications
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  after_create :assign_user_to_email_notifications
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   #We have turn on the timeout => which automatically logs the user out after 2 hours(set it by us), and the trackable
@@ -14,5 +15,18 @@ class User < ApplicationRecord
 
   def role?(role)
     roles.any? { |r| r.role_name.underscore.to_sym == role }
+  end
+
+  private
+  # After the site admin has created a new user, we want to assign all types of email notifications to that user, so that
+  # all email notifications are deactivated and we will choose which ones should have activated after.
+
+  def assign_user_to_email_notifications
+    # For each type of notification, we want to create an assignEmailNotification active = false for that user.
+    if !EmailNotification.all.empty?
+      EmailNotification.all.each do |en|
+       AssignEmailNotification.create(user_id: self.id, email_notification_id: en.id)
+      end
+    end
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  attr_accessor :selected_email
   after_create :assign_user_to_email_notifications
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
@@ -12,7 +13,7 @@ class User < ApplicationRecord
   has_many :roles, through: :assignments
   has_many :assign_email_notifications
   has_many :email_notifications, through: :assign_email_notifications
-
+  accepts_nested_attributes_for :email_notifications
   def role?(role)
     roles.any? { |r| r.role_name.underscore.to_sym == role }
   end
@@ -20,12 +21,13 @@ class User < ApplicationRecord
   private
   # After the site admin has created a new user, we want to assign all types of email notifications to that user, so that
   # all email notifications are deactivated and we will choose which ones should have activated after.
-
   def assign_user_to_email_notifications
     # For each type of notification, we want to create an assignEmailNotification active = false for that user.
+    # First we make sure EmailNotification doesn't return an empty array
     if !EmailNotification.all.empty?
       EmailNotification.all.each do |en|
-       AssignEmailNotification.create(user_id: self.id, email_notification_id: en.id)
+        # For each type of email notification we assign it to a user, with active=false (is by default that state)
+        AssignEmailNotification.create(user_id: self.id, email_notification_id: en.id)
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,8 +9,10 @@ class User < ApplicationRecord
 
   has_many :assignments
   has_many :roles, through: :assignments
+  has_many :assign_email_notifications
+  has_many :email_notifications, through: :assign_email_notifications
 
   def role?(role)
-  roles.any? { |r| r.role_name.underscore.to_sym == role }
-end
+    roles.any? { |r| r.role_name.underscore.to_sym == role }
+  end
 end

--- a/app/policies/administrator/assign_email_notification_policy.rb
+++ b/app/policies/administrator/assign_email_notification_policy.rb
@@ -7,6 +7,9 @@ class Administrator::AssignEmailNotificationPolicy < ApplicationPolicy
       end
     end
   end
+  def index?
+    true
+  end
   def new?
     user.role? :admin
   end

--- a/app/policies/administrator/assign_email_notification_policy.rb
+++ b/app/policies/administrator/assign_email_notification_policy.rb
@@ -1,0 +1,28 @@
+class Administrator::AssignEmailNotificationPolicy < ApplicationPolicy
+  # Only site admins can CRUD Assign Emails Notifications to Users
+  class Scope < Scope
+    def resolve
+      if user.role? :admin
+        scope.all
+      end
+    end
+  end
+  def new?
+    user.role? :admin
+  end
+  def create?
+    user.role? :admin
+  end
+
+  def edit?
+    user.role? :admin
+  end
+
+  def update?
+    user.role? :admin
+  end
+
+  def destroy?
+    user.role? :admin
+  end
+end

--- a/app/views/administrator/assign_email_notifications/index.html.erb
+++ b/app/views/administrator/assign_email_notifications/index.html.erb
@@ -1,15 +1,10 @@
-<%= @user.email  %>
+User: <%= @user.email  %>
+    <ul>
+      <% @notifications.each do |n| %>
+        <li>
+          <%= n.email_notification.notification %><%= link_to  "#{n.display_status}", administrator_change_status_path(@user.id, n.id), method: :put, remote:true %>
+        </li>
+      <% end %>
+    </ul>
 
-<% form_tag(:action => "update", {:class => "form"}) do %>
-
-<% end -%>
-
-
-
-
-<ul>
-  <% @notifications.each do |n|  %>
-    <li><%= n.notification %></li>
-  <% end %>
-</ul>
 

--- a/app/views/administrator/assign_email_notifications/index.html.erb
+++ b/app/views/administrator/assign_email_notifications/index.html.erb
@@ -1,6 +1,15 @@
 <%= @user.email  %>
+
+<% form_tag(:action => "update", {:class => "form"}) do %>
+
+<% end -%>
+
+
+
+
 <ul>
   <% @notifications.each do |n|  %>
     <li><%= n.notification %></li>
   <% end %>
 </ul>
+

--- a/app/views/administrator/assign_email_notifications/index.html.erb
+++ b/app/views/administrator/assign_email_notifications/index.html.erb
@@ -1,0 +1,6 @@
+<%= @user.email  %>
+<ul>
+  <% @notifications.each do |n|  %>
+    <li><%= n.notification %></li>
+  <% end %>
+</ul>

--- a/db/migrate/20210903190553_create_assign_email_notifications.rb
+++ b/db/migrate/20210903190553_create_assign_email_notifications.rb
@@ -1,0 +1,10 @@
+class CreateAssignEmailNotifications < ActiveRecord::Migration[6.0]
+  def change
+    create_table :assign_email_notifications do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :email_notification, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210904054101_add_active_column_in_assign_email_notification.rb
+++ b/db/migrate/20210904054101_add_active_column_in_assign_email_notification.rb
@@ -1,0 +1,5 @@
+class AddActiveColumnInAssignEmailNotification < ActiveRecord::Migration[6.0]
+  def change
+    add_column :email_notifications, :active, :boolean, :default => false
+  end
+end

--- a/db/migrate/20210904064717_remove_column_active_of_email_notification_and_add_column_active_to_assign_email_notification.rb
+++ b/db/migrate/20210904064717_remove_column_active_of_email_notification_and_add_column_active_to_assign_email_notification.rb
@@ -1,0 +1,6 @@
+class RemoveColumnActiveOfEmailNotificationAndAddColumnActiveToAssignEmailNotification < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :email_notifications, :active
+    add_column :assign_email_notifications, :active, :boolean, :default => false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_04_054101) do
+ActiveRecord::Schema.define(version: 2021_09_04_064717) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 2021_09_04_054101) do
     t.bigint "email_notification_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "active", default: false
     t.index ["email_notification_id"], name: "index_assign_email_notifications_on_email_notification_id"
     t.index ["user_id"], name: "index_assign_email_notifications_on_user_id"
   end
@@ -56,7 +57,6 @@ ActiveRecord::Schema.define(version: 2021_09_04_054101) do
     t.string "description"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.boolean "active", default: false
   end
 
   create_table "genres", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_03_184915) do
+ActiveRecord::Schema.define(version: 2021_09_03_190553) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,6 +19,15 @@ ActiveRecord::Schema.define(version: 2021_09_03_184915) do
     t.string "type_of_area"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+  end
+
+  create_table "assign_email_notifications", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "email_notification_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["email_notification_id"], name: "index_assign_email_notifications_on_email_notification_id"
+    t.index ["user_id"], name: "index_assign_email_notifications_on_user_id"
   end
 
   create_table "assignments", force: :cascade do |t|
@@ -122,6 +131,8 @@ ActiveRecord::Schema.define(version: 2021_09_03_184915) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  add_foreign_key "assign_email_notifications", "email_notifications"
+  add_foreign_key "assign_email_notifications", "users"
   add_foreign_key "assignments", "roles"
   add_foreign_key "assignments", "users"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_09_03_190553) do
+ActiveRecord::Schema.define(version: 2021_09_04_054101) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -56,6 +56,7 @@ ActiveRecord::Schema.define(version: 2021_09_03_190553) do
     t.string "description"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "active", default: false
   end
 
   create_table "genres", force: :cascade do |t|

--- a/test/controllers/administrator/assign_email_notifications_controller_test.rb
+++ b/test/controllers/administrator/assign_email_notifications_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Administrator::AssignEmailNotificationsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/assign_email_notifications.yml
+++ b/test/fixtures/assign_email_notifications.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  user: one
+  email_notification: one
+
+two:
+  user: two
+  email_notification: two

--- a/test/models/assign_email_notification_test.rb
+++ b/test/models/assign_email_notification_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class AssignEmailNotificationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/policies/administrator/assign_email_notification_policy_test.rb
+++ b/test/policies/administrator/assign_email_notification_policy_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+class Administrator::AssignEmailNotificationPolicyTest < ActiveSupport::TestCase
+  def test_scope
+  end
+
+  def test_show
+  end
+
+  def test_create
+  end
+
+  def test_update
+  end
+
+  def test_destroy
+  end
+end


### PR DESCRIPTION
Need: The site admin, needs to be capable if activating and deactivating individually types of email alert for each user.
- When a user is created, assign_user_to_email_notifications gets called, this action assigns to the new user all the different types of email notifications, but deactivated.
- From the index view of assign emails by clicking in on/off the site admin is capable of activating or deactivating the different alerts for that specific user. This link calls a method in the controller that call an method in the class that is in charge of updating this specific attribute.