### PR TITLE
User management

### DIFF
--- a/app/assets/stylesheets/administrator/users_management.scss
+++ b/app/assets/stylesheets/administrator/users_management.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the administrator/users_management controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/administrator/users_management_controller.rb
+++ b/app/controllers/administrator/users_management_controller.rb
@@ -1,0 +1,29 @@
+class Administrator::UsersManagementController < ApplicationController
+  # Pundit is a model based authorization gem. We can not use it this controller, because it doesn't have a model associated to it.
+  # That's why we need to callback this function, to make sure ONLY Site admins can CRUD users.
+  before_action :check_if_user_is_admin
+  def index
+    @users = User.all
+  end
+
+  def new
+    @user = User.new()
+  end
+
+  def create
+    @user = User.new(user_params)
+    raise
+  end
+
+  private
+
+  def check_if_user_is_admin
+    if !current_user.role? :admin
+      redirect_to root_path, alert: 'No tienes autorización para acceder a este espacio.'
+    end
+  end
+
+  def user_params
+    params.require(:user).permit(:first_name, :last_name, :email)
+  end
+end

--- a/app/controllers/administrator/users_management_controller.rb
+++ b/app/controllers/administrator/users_management_controller.rb
@@ -31,6 +31,19 @@ class Administrator::UsersManagementController < ApplicationController
     end
   end
 
+  def edit
+    @user = User.find(params[:id])
+  end
+
+  def update
+    @user = User.find(params[:id])
+    if @user.update(user_params)
+      redirect_to administrator_users_path, notice: 'Usuario actualizado correctamente'
+    else
+      render :edit, alert:'No se ha podido actualizar al usuario'
+    end
+  end
+
   private
 
   def check_if_user_is_admin

--- a/app/controllers/administrator/users_management_controller.rb
+++ b/app/controllers/administrator/users_management_controller.rb
@@ -3,6 +3,7 @@ class Administrator::UsersManagementController < ApplicationController
   # That's why we need to callback this function, to make sure ONLY Site admins can CRUD users.
   before_action :check_if_user_is_admin
   after_action :send_welcome_email_to_user, only: [:create]
+  before_action :destroy_assignments_associated_to_user, only: [:destroy]
   def index
     @users = User.all
   end
@@ -21,6 +22,15 @@ class Administrator::UsersManagementController < ApplicationController
     end
   end
 
+  def destroy
+    @user = User.find(params[:id])
+    if @user.destroy
+      redirect_to administrator_users_path, notice: 'User eliminado correctamente'
+    else
+      render :index, alert: 'No se ha podido eliminar el usuario'
+    end
+  end
+
   private
 
   def check_if_user_is_admin
@@ -32,6 +42,13 @@ class Administrator::UsersManagementController < ApplicationController
 
   def send_welcome_email_to_user
     # AFTE CREATING A USER AN EMAIL WELCOMING HIM/HER WITH HIS/HER PASSWORD WILL BE SEND!
+  end
+
+  def destroy_assignments_associated_to_user
+    # Due to the N:N association, we need first to delete the associtions of the user before deleting the user
+    @user = User.find(params[:id])
+    @user.assignments.destroy_all
+    @user.assign_email_notifications.destroy_all
   end
 
   def user_params

--- a/app/controllers/administrator/users_management_controller.rb
+++ b/app/controllers/administrator/users_management_controller.rb
@@ -2,6 +2,7 @@ class Administrator::UsersManagementController < ApplicationController
   # Pundit is a model based authorization gem. We can not use it this controller, because it doesn't have a model associated to it.
   # That's why we need to callback this function, to make sure ONLY Site admins can CRUD users.
   before_action :check_if_user_is_admin
+  after_action :send_welcome_email_to_user, only: [:create]
   def index
     @users = User.all
   end
@@ -12,18 +13,28 @@ class Administrator::UsersManagementController < ApplicationController
 
   def create
     @user = User.new(user_params)
-    raise
+    @user.password = @user.set_users_password
+    if @user.save
+      redirect_to administrator_users_path, notice: 'Usuario creado correctamente'
+    else
+      render :new
+    end
   end
 
   private
 
   def check_if_user_is_admin
+    # Only admins can CRUD users.user
     if !current_user.role? :admin
       redirect_to root_path, alert: 'No tienes autorización para acceder a este espacio.'
     end
   end
 
+  def send_welcome_email_to_user
+    # AFTE CREATING A USER AN EMAIL WELCOMING HIM/HER WITH HIS/HER PASSWORD WILL BE SEND!
+  end
+
   def user_params
-    params.require(:user).permit(:first_name, :last_name, :email)
+    params.require(:user).permit(:first_name, :last_name, :email, role_ids:[])
   end
 end

--- a/app/helpers/administrator/users_management_helper.rb
+++ b/app/helpers/administrator/users_management_helper.rb
@@ -1,0 +1,2 @@
+module Administrator::UsersManagementHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,19 +1,19 @@
 class User < ApplicationRecord
-  attr_accessor :selected_email
   after_create :assign_user_to_email_notifications
+  validates :first_name, presence: true
+  validates :last_name, presence: true
+  validates :email, presence: true, uniqueness: true
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   #We have turn on the timeout => which automatically logs the user out after 2 hours(set it by us), and the trackable
   #module to being able to track users.
-  devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :validatable,
-         :trackable, :timeoutable
+  devise :database_authenticatable,
+         :recoverable, :rememberable, :validatable
 
   has_many :assignments
   has_many :roles, through: :assignments
   has_many :assign_email_notifications
   has_many :email_notifications, through: :assign_email_notifications
-  accepts_nested_attributes_for :email_notifications
   def role?(role)
     roles.any? { |r| r.role_name.underscore.to_sym == role }
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,6 +3,7 @@ class User < ApplicationRecord
   validates :first_name, presence: true
   validates :last_name, presence: true
   validates :email, presence: true, uniqueness: true
+  validates :roles, presence: true
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   #We have turn on the timeout => which automatically logs the user out after 2 hours(set it by us), and the trackable
@@ -16,6 +17,14 @@ class User < ApplicationRecord
   has_many :email_notifications, through: :assign_email_notifications
   def role?(role)
     roles.any? { |r| r.role_name.underscore.to_sym == role }
+  end
+
+  def set_users_password
+    number_chain = []
+    5.times do
+      number_chain.push((0...9).to_a.sample())
+    end
+    return "#{first_name}#{number_chain.join("")}"
   end
 
   private

--- a/app/views/administrator/assign_email_notifications/index.html.erb
+++ b/app/views/administrator/assign_email_notifications/index.html.erb
@@ -1,10 +1,10 @@
 User: <%= @user.email  %>
-    <ul>
-      <% @notifications.each do |n| %>
-        <li>
-          <%= n.email_notification.notification %><%= link_to  "#{n.display_status}", administrator_change_status_path(@user.id, n.id), method: :put, remote:true %>
-        </li>
-      <% end %>
-    </ul>
+<ul>
+  <% @notifications.each do |n| %>
+    <li>
+      <%= n.email_notification.notification %><%= link_to  "#{n.display_status}", administrator_change_status_path(@user.id, n.id), method: :put, remote:true %>
+    </li>
+  <% end %>
+</ul>
 
 

--- a/app/views/administrator/users_management/edit.html.erb
+++ b/app/views/administrator/users_management/edit.html.erb
@@ -1,0 +1,7 @@
+<%= simple_form_for [:administrator, @user], url: administrator_update_user_path do |f| %>
+  <%= f.input :first_name, required: true %>
+  <%= f.input :last_name, required: true %>
+  <%= f.input :email, required: true %>
+  <%= f.association :roles,label_method: :role_name, value_method: :id, :as => :check_boxes %>
+  <%= f.submit "Actualizar", class: "btn btn_cta"  %>
+<% end %>

--- a/app/views/administrator/users_management/index.html.erb
+++ b/app/views/administrator/users_management/index.html.erb
@@ -1,5 +1,8 @@
 <ol>
   <% @users.each do |user| %>
-    <li><%= user.first_name %> <%= user.last_name %> <%= user.roles.first.role_name %> <%= user.email %></li>
+    <li>
+      <%= user.first_name %> <%= user.last_name %> <%= user.roles.first.role_name %> <%= user.email %>
+      <%= link_to 'Eliminar', administrator_delete_user_path(user), data: {:confirm =>'¿Eliminar este usuario?'},method: :delete  %>
+    </li>
   <% end %>
 </ol>

--- a/app/views/administrator/users_management/index.html.erb
+++ b/app/views/administrator/users_management/index.html.erb
@@ -1,0 +1,5 @@
+<ol>
+  <% @users.each do |user| %>
+    <li><%= user.first_name %> <%= user.last_name %> <%= user.roles.first.role_name %> <%= user.email %></li>
+  <% end %>
+</ol>

--- a/app/views/administrator/users_management/index.html.erb
+++ b/app/views/administrator/users_management/index.html.erb
@@ -2,6 +2,7 @@
   <% @users.each do |user| %>
     <li>
       <%= user.first_name %> <%= user.last_name %> <%= user.roles.first.role_name %> <%= user.email %>
+      <%= link_to 'Actualizar', administrator_edit_user_path(user) %>
       <%= link_to 'Eliminar', administrator_delete_user_path(user), data: {:confirm =>'¿Eliminar este usuario?'},method: :delete  %>
     </li>
   <% end %>

--- a/app/views/administrator/users_management/new.html.erb
+++ b/app/views/administrator/users_management/new.html.erb
@@ -2,5 +2,6 @@
   <%= f.input :first_name, required: true %>
   <%= f.input :last_name, required: true %>
   <%= f.input :email, required: true %>
+  <%= f.association :roles,label_method: :role_name, value_method: :id, :as => :check_boxes %>
   <%= f.submit "Añadir", class: "btn btn_cta"  %>
 <% end %>

--- a/app/views/administrator/users_management/new.html.erb
+++ b/app/views/administrator/users_management/new.html.erb
@@ -1,0 +1,6 @@
+<%= simple_form_for [:administrator, @user], url: administrator_create_user_path do |f| %>
+  <%= f.input :first_name, required: true %>
+  <%= f.input :last_name, required: true %>
+  <%= f.input :email, required: true %>
+  <%= f.submit "Añadir", class: "btn btn_cta"  %>
+<% end %>

--- a/test/controllers/administrator/users_management_controller_test.rb
+++ b/test/controllers/administrator/users_management_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class Administrator::UsersManagementControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
A user can be created only by the site admin, that's why i have created a method 'check_if_user_is_admin', that is called in a callback 'before action' in the users_management controller. Be can't use Pundit here, because we are not using a Model in this controller and Pundit is a Model-based authorization system. We bypass this using a callback before any action that checks if the current user is an admin or not.

Also I have: 
- Created CRUD actions for User
- Password is set automatically by the system and get's send directly to the user when it's create
- Before a user is deleted, due to the FK relationships i have to create a 'destroy_assignments_associated_to_user' method to delete al FK before a user is deleted to avoid errors.