### PR TITLE
Added AWS create folder method when a new employees is created

### DIFF
--- a/app/controllers/passwords_controller.rb
+++ b/app/controllers/passwords_controller.rb
@@ -5,13 +5,13 @@ class PasswordsController < Devise::PasswordsController
     if resource.company.users.size <= 1
       create_bucket(resource)
     end
-    workers_path
+    employees_path
   end
   def create_bucket(user)
     # Create a bucket for eac company that sign's up. When do we create it? when the user is confirmed? When the company is created?
     c = Aws::S3::Client.new(region: 'eu-west-1', access_key_id: ENV['AWS_ACCESS_KEY_ID'], secret_access_key: ENV['SECRET_ACCESS_KEY'])
     bucket_name = "#{user.company.name_of_company.parameterize}-#{user.company.id}"
-    c.create_bucket(bucket: bucket_name)
+    c.create_bucket(bucket: bucket_name, acl: 'private')
     # MAKE THE BUCKET BLOCK ALL PUBLIC!
     # USE CREATE BUCKET METHOD IN THIS WEB: https://docs.aws.amazon.com/sdk-for-ruby/v3/developer-guide/s3-example-create-buckets.html
   end

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -16,9 +16,6 @@ class Employee < User
   validates :avatar, content_type: 'image/png',content_type: [:png, :jpg, :jpeg], limit: {min: 1, max: 1 }
   validates :files, content_type: [ :pdf, :doc, :docx, :xls, :xlsx], limit: {min:0, max: 7 }
   # **** RELATIONS ****
-  has_many :permissions
-  has_many :sicks
-  has_many :notes
   has_one_attached :avatar
   has_many_attached :files
   #belongs_to :area

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,9 +12,12 @@ class User < ApplicationRecord
   devise :database_authenticatable,
          :recoverable, :rememberable, :validatable, :confirmable
 
-  has_many :assignments
+  has_many :assignments, dependent: :destroy
   has_many :roles, through: :assignments
   has_many :assign_email_notifications
+  has_many :permissions, dependent: :destroy
+  has_many :sicks, dependent: :destroy
+  has_many :notes, dependent: :destroy
   has_many :email_notifications, through: :assign_email_notifications
   belongs_to :company
   def role?(role)


### PR DESCRIPTION
Everytime a new employee is created, a folder in the AWS bucket for the company is created for that employee. 
If we get an error from AWS, the folder doesn't get created and the employee is deleted, displaying an error message.